### PR TITLE
Rename 'testable' with 'testables'

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ And update the test code:
 viewController.username = "devxoul"
 
 // then
-let usernameLabel = viewController.testable[\.usernameLabel] // ✅
+let usernameLabel = viewController.testables[\.usernameLabel] // ✅
 XCTAssertEqual(usernameLabel.text, "devxoul")
 ```
 

--- a/Sources/Testables/Testables.swift
+++ b/Sources/Testables/Testables.swift
@@ -4,7 +4,7 @@ public protocol Testable {
 }
 
 public extension Testable {
-  var testable: TestableKeys {
+  var testables: TestableKeys {
     return TestableKeys.init(base: self)
   }
 }

--- a/Tests/TestablesTests/ProfileViewControllerTests.swift
+++ b/Tests/TestablesTests/ProfileViewControllerTests.swift
@@ -15,17 +15,17 @@ final class ProfileViewControllerTests: XCTestCase {
     self.viewController.username = "devxoul"
 
     // then
-    let usernameLabel = self.viewController.testable[\.usernameLabel]
+    let usernameLabel = self.viewController.testables[\.usernameLabel]
     XCTAssertEqual(usernameLabel.text, "devxoul")
   }
 
   func testFollowButton_isSelected() {
     // when
-    self.viewController.testable[\.isFollowing] = true
+    self.viewController.testables[\.isFollowing] = true
 
     // then
-    let followButton = self.viewController.testable[\.followButton]
+    let followButton = self.viewController.testables[\.followButton]
     XCTAssertTrue(followButton.isSelected)
-    XCTAssertTrue(self.viewController.testable[\.isFollowing])
+    XCTAssertTrue(self.viewController.testables[\.isFollowing])
   }
 }


### PR DESCRIPTION
Rename `testable` with `testables` as @wplong11 suggested.

This PR breaks existing API:

```diff
- profileViewController.testable[\.usernameLabel]
+ profileViewController.testables[\.usernameLabel]
```